### PR TITLE
added format compatible with pypi for easier installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # logs
 logs/
 
+.pypirc
+
 # Python-generated files
 __pycache__/
 *.py[oc]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FastOpp - Easier AI Web Apps for Students
 
-![FastOpp Logo](docs/images/fastopp_logo.webp)
+![FastOpp Logo](https://raw.githubusercontent.com/Oppkey/fastopp/refs/heads/main/docs/images/fastopp_logo.webp)
 
 ## What
 
@@ -118,58 +118,58 @@ output of an LLM.
 
 ### Clickable Cards with Mouseover
 
-![home](docs/images/readme/home.webp)
+![home](https://raw.githubusercontent.com/Oppkey/fastopp/refs/heads/main/docs/images/readme/home.webp)
 
 ### Change Images Without Page Reload
 
-![interactive](docs/images/interactive.webp)
+![interactive](https://raw.githubusercontent.com/Oppkey/fastopp/refs/heads/main/docs/images/interactive.webp)
 
 ### Hero
 
-![hero](docs/images/readme/hero.webp)
+![hero](https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/readme/hero.webp)
 
 ### Database Admin List
 
-![admin list](docs/images/admin.webp)
+![admin list](https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/admin.webp)
 
 ### Database Entry Edit
 
-![edit](docs/images/edit.webp)
+![edit](https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/edit.webp)
 
 ### User Management
 
-![user management](docs/images/user_management.webp)
+![user management](https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/user_management.webp)
 
 ### User Authentication
 
 Admin panel is restricted to logged-in users.
 
-![authentication](docs/images/login.webp)
+![authentication](https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/login.webp)
 
 ### Statistics Hero Card
 
-![webinar top](docs/images/webinar_top.webp)
+![webinar top](https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/webinar_top.webp)
 
 ### People Hero Card
 
-![webinar people](docs/images/webinar_people.webp)
+![webinar people](https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/webinar_people.webp)
 
 ### AI Chat with Cloud-Based LLM
 
-![AI Chat](docs/images/ai_chat_indents.webp)
+![AI Chat](https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/ai_chat_indents.webp)
 
-![AI Chat](docs/images/ai_chat.webp)
+![AI Chat](https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/ai_chat.webp)
 
 ### Emergency Access From Web Browser
 
 * create admin if you forgot password or have no shell or database access
 * ability to disable access with environment variable
 
-![emergency login](docs/images/readme/emergency_login.webp)
+![emergency login](https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/readme/emergency_login.webp)
 
 ### Admin Dashhboards to Change Password and Manage Database
 
-![oppman web admin](docs/images/readme/password_migration.webp)
+![oppman web admin](https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/readme/password_migration.webp)
 
 ### Manage Reference Demos From WebUI
 
@@ -179,7 +179,7 @@ Create fake data for testing
 * fake webinar registrants
 * fake products for sales and marketing tests
 
-![oppdemo dashboard](docs/images/readme/oppdemo.webp)
+![oppdemo dashboard](https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/readme/oppdemo.webp)
 
 ## Basic Design System and Reference Template
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,331 @@
+# Contributing to FastOpp
+
+Thank you for your interest in contributing to FastOpp! This guide will help you understand how to contribute to the project and publish changes to PyPI.
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.12 or higher
+- `uv` package manager
+- Git
+
+### Initial Setup
+
+1. **Clone the repository**:
+   ```bash
+   git clone <repository-url>
+   cd fastopp
+   ```
+
+2. **Install dependencies**:
+   ```bash
+   uv sync
+   ```
+
+3. **Run the application**:
+   ```bash
+   uv run python main.py
+   ```
+
+## Making Changes
+
+### Development Workflow
+
+1. **Create a feature branch**:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **Make your changes** and test them:
+   ```bash
+   # Run tests
+   uv run pytest
+   
+   # Run linting
+   uv run ruff check .
+   uv run mypy .
+   ```
+
+3. **Update version** in `pyproject.toml` if needed:
+   ```toml
+   version = "0.2.2"  # Increment version number
+   ```
+
+4. **Commit your changes**:
+   ```bash
+   git add .
+   git commit -m "feat: add new feature"
+   ```
+
+## Publishing Changes to PyPI
+
+### Prerequisites for Publishing
+
+#### For Maintainers (Project Owners)
+
+1. **PyPI Account**: Create an account at https://pypi.org/account/register/
+2. **API Token**: Generate an API token from your PyPI account settings
+3. **Environment Variables**: Set up your credentials
+
+#### For Contributors
+
+**Important**: Only maintainers with PyPI access can publish releases. Contributors should:
+
+1. **Submit Pull Requests** with their changes
+2. **Let maintainers handle publishing** to PyPI
+3. **Test locally** using `uv add .` to verify their changes work
+
+#### Sharing PyPI Access (For Maintainers Only)
+
+If you need to grant PyPI access to trusted contributors:
+
+1. **Go to PyPI project settings**: https://pypi.org/manage/project/fastopp/collaboration/
+2. **Add collaborators** with appropriate permissions:
+   - **Owner**: Full access (can add/remove other collaborators)
+   - **Maintainer**: Can upload new releases
+3. **Share credentials securely**:
+   - Use secure communication (encrypted email, secure messaging)
+   - Never share credentials in public channels
+   - Consider using team API tokens if available
+
+### Publishing Process
+
+#### Method 1: Using Environment Variables (Recommended)
+
+1. **Set environment variables**:
+   ```bash
+   export TWINE_USERNAME=__token__
+   export TWINE_PASSWORD=your-pypi-api-token
+   ```
+
+2. **Build the package**:
+   ```bash
+   uv build
+   ```
+
+3. **Upload to PyPI**:
+   ```bash
+   uv run twine upload dist/*
+   ```
+
+#### Method 2: Using .pypirc File
+
+1. **Create/update `.pypirc`** in your home directory:
+   ```ini
+   [pypi]
+   username = __token__
+   password = your-pypi-api-token
+   ```
+
+2. **Build and upload**:
+   ```bash
+   uv build
+   uv run twine upload dist/*
+   ```
+
+#### Method 3: Direct Command with Credentials
+
+```bash
+TWINE_USERNAME=__token__ TWINE_PASSWORD=your-token uv run twine upload dist/*
+```
+
+### Testing Before Publishing
+
+#### Test on TestPyPI (Optional)
+
+1. **Create TestPyPI account** at https://test.pypi.org/
+2. **Get TestPyPI token** from your TestPyPI account
+3. **Upload to TestPyPI first**:
+   ```bash
+   TWINE_USERNAME=__token__ TWINE_PASSWORD=your-testpypi-token uv run twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+   ```
+4. **Test installation from TestPyPI**:
+   ```bash
+   uv add --index-url https://test.pypi.org/simple/ fastopp
+   ```
+
+### Complete Publishing Workflow
+
+```bash
+# 1. Update version in pyproject.toml
+# 2. Build the package
+uv build
+
+# 3. Upload to PyPI
+```text
+TWINE_USERNAME=__token__ 
+TWINE_PASSWORD=your-token 
+uv run twine upload dist/*
+```
+
+# 4. Verify the upload
+# Visit: https://pypi.org/project/fastopp/
+```
+
+## Version Management
+
+### Semantic Versioning
+
+Follow semantic versioning (SemVer):
+- **MAJOR** (1.0.0): Breaking changes
+- **MINOR** (0.1.0): New features, backward compatible
+- **PATCH** (0.0.1): Bug fixes, backward compatible
+
+### Updating Version
+
+1. **Edit `pyproject.toml`**:
+   ```toml
+   version = "0.2.2"  # Update version number
+   ```
+
+2. **Rebuild and publish**:
+   ```bash
+   uv build
+   TWINE_USERNAME=__token__ TWINE_PASSWORD=your-token uv run twine upload dist/*
+   ```
+
+## Code Quality
+
+### Linting and Formatting
+
+```bash
+# Run linting
+uv run ruff check .
+
+# Auto-fix linting issues
+uv run ruff check . --fix
+
+# Type checking
+uv run mypy .
+```
+
+### Testing
+
+```bash
+# Run all tests
+uv run pytest
+
+# Run with coverage
+uv run pytest --cov=fastopp
+
+# Run specific test file
+uv run pytest tests/test_specific.py
+```
+
+## Pull Request Process
+
+### For Contributors
+
+1. **Fork the repository**
+2. **Create a feature branch**
+3. **Make your changes**
+4. **Add tests** for new functionality
+5. **Update documentation** if needed
+6. **Test locally** with `uv add .`
+7. **Submit a pull request**
+
+### For Maintainers
+
+1. **Review pull requests**
+2. **Test changes** thoroughly
+3. **Merge approved changes**
+4. **Update version** in `pyproject.toml`
+5. **Build and publish** to PyPI:
+   ```bash
+   uv build
+   TWINE_USERNAME=__token__ TWINE_PASSWORD=your-token uv run twine upload dist/*
+   ```
+
+### Pull Request Guidelines
+
+- **Clear description** of changes
+- **Reference issues** if applicable
+- **Include tests** for new features
+- **Update documentation** as needed
+- **Follow coding standards**
+
+## Troubleshooting
+
+### Common Issues
+
+#### 403 Forbidden Error
+- **Cause**: Invalid API token or wrong repository
+- **Solution**: Verify your PyPI token and repository URL
+
+#### Build Errors
+- **Cause**: Missing dependencies or configuration issues
+- **Solution**: Run `uv sync` and check `pyproject.toml`
+
+#### Upload Failures
+- **Cause**: Network issues or authentication problems
+- **Solution**: Check your internet connection and API token
+
+### Getting Help
+
+- **Issues**: Create an issue on GitHub
+- **Discussions**: Use GitHub Discussions for questions
+- **Documentation**: Check the docs/ directory for more information
+
+## Security
+
+### API Token Security
+
+- **Never commit** API tokens to version control
+- **Use environment variables** for credentials
+- **Rotate tokens** regularly
+- **Use `.gitignore`** to exclude sensitive files
+
+### Access Management
+
+#### Who Can Publish?
+
+- **Project Owners**: Full PyPI access
+- **Maintainers**: Can upload releases (if granted access)
+- **Contributors**: Submit PRs only (no direct PyPI access)
+
+#### Granting PyPI Access
+
+1. **Go to PyPI project settings**: https://pypi.org/manage/project/fastopp/collaboration/
+2. **Add team members** with appropriate roles:
+   - **Owner**: Full project control
+   - **Maintainer**: Can upload releases
+3. **Share credentials securely**:
+   - Use encrypted communication
+   - Never share in public channels
+   - Consider using organization accounts for teams
+
+#### Best Practices
+
+- **Limit access** to trusted maintainers only
+- **Use separate tokens** for different environments
+- **Monitor upload activity** regularly
+- **Revoke access** when team members leave
+
+### Best Practices
+
+- **Review changes** before publishing
+- **Test thoroughly** in development
+- **Use semantic versioning**
+- **Document breaking changes**
+
+## Release Checklist
+
+Before publishing a new version:
+
+- [ ] **Version updated** in `pyproject.toml`
+- [ ] **Tests passing** (`uv run pytest`)
+- [ ] **Linting clean** (`uv run ruff check .`)
+- [ ] **Documentation updated**
+- [ ] **Changelog updated**
+- [ ] **Package builds** (`uv build`)
+- [ ] **Ready to publish** to PyPI
+
+## Contact
+
+For questions about contributing:
+- **GitHub Issues**: Report bugs and request features
+- **GitHub Discussions**: Ask questions and discuss ideas
+- **Email**: Contact the maintainers directly
+
+Thank you for contributing to FastOpp! 🚀

--- a/fastopp/__init__.py
+++ b/fastopp/__init__.py
@@ -1,0 +1,300 @@
+# =========================
+# main.py
+# =========================
+from pathlib import Path
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from fastapi.staticfiles import StaticFiles
+from fastapi.security import HTTPBasic
+from starlette.middleware.sessions import SessionMiddleware
+from dotenv import load_dotenv
+from admin.setup import setup_admin
+from routes.chat import router as chat_router
+from routes.api import router as api_router
+from routes.health import router as health_router
+try:
+    from routes.auth import router as auth_router
+except Exception:
+    auth_router = None  # Optional during partial restores
+from routes.pages import router as pages_router
+try:
+    from routes.webinar import router as webinar_router
+except Exception:
+    webinar_router = None  # Optional during partial restores
+try:
+    from routes.oppman import router as oppman_router
+except Exception:
+    oppman_router = None  # Optional during partial restores
+try:
+    from routes.oppdemo import router as oppdemo_router
+except Exception:
+    oppdemo_router = None  # Optional during partial restores
+
+# Import dependency injection modules
+from dependencies.database import create_database_engine, create_session_factory
+from dependencies.config import get_settings
+
+# Load environment variables
+load_dotenv()
+
+# Get settings using dependency injection
+settings = get_settings()
+
+# Initialize storage system (handles directory creation gracefully)
+try:
+    from services.storage import get_storage
+    storage = get_storage()
+    # Ensure required directories exist
+    storage.ensure_directories("photos", "sample_photos")
+except Exception as e:
+    print(f"Warning: Storage initialization failed: {e}")
+    print("Application will continue but file uploads may not work.")
+
+# from users import fastapi_users, auth_backend  # type: ignore
+
+app = FastAPI()
+app.add_middleware(SessionMiddleware, secret_key=settings.secret_key)
+
+
+# Add proxy headers middleware for production deployments
+@app.middleware("http")
+async def proxy_headers_middleware(request: Request, call_next):
+    """Middleware to handle proxy headers for production deployments"""
+    # Check if we're behind a proxy (Railway, Fly, etc.)
+    if request.headers.get("x-forwarded-proto") == "https":
+        request.scope["scheme"] = "https"
+
+    # Don't modify scope["type"] - it should remain "http" for HTTP requests
+
+    response = await call_next(request)
+    return response
+
+
+# Setup dependencies
+def setup_dependencies(app: FastAPI):
+    """Setup application dependencies"""
+    # Create database engine and session factory
+    engine = create_database_engine(settings)
+    session_factory = create_session_factory(engine)
+
+    # Store in app state for dependency injection
+    app.state.db_engine = engine
+    app.state.session_factory = session_factory
+    app.state.settings = settings
+
+    print(f"✅ Dependencies setup complete - session_factory: {session_factory}")
+    print(f"✅ App state after setup: {list(app.state.__dict__.keys())}")
+
+
+# Setup dependencies immediately
+setup_dependencies(app)
+
+# Mount uploads directory based on environment (MUST come before /static mount)
+if settings.upload_dir != "static/uploads":
+    # In production environments, mount the uploads directory separately
+    # Only mount if the directory exists (serverless environments may not have writable directories)
+    upload_path = Path(settings.upload_dir)
+    if upload_path.exists():
+        app.mount("/static/uploads", StaticFiles(directory=settings.upload_dir), name="uploads")
+    else:
+        print(f"Warning: Upload directory '{settings.upload_dir}' does not exist. Skipping static file mounting.")
+
+# Mount static files (MUST come after /static/uploads to avoid conflicts)
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+# SQLAdmin automatically handles static file serving at /admin/statics/
+# No manual mounting required - SQLAdmin does this internally
+
+templates = Jinja2Templates(directory="templates")
+security = HTTPBasic()
+
+
+# Setup admin interface
+setup_admin(app, settings.secret_key)
+
+# Add custom routes to handle missing FontAwesome font files
+@app.get("/admin/statics/webfonts/{font_file}")
+async def serve_font_files(font_file: str):
+    """Redirect all font requests to CDN to prevent 404 errors and font loading issues"""
+    try:
+        from fastapi.responses import RedirectResponse
+        
+        # Map all possible font files to CDN equivalents
+        font_mapping = {
+            "fa-solid-900.woff2": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-solid-900.woff2",
+            "fa-solid-900.woff": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-solid-900.woff",
+            "fa-solid-900.ttf": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-solid-900.ttf",
+            "fa-solid-900.eot": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-solid-900.eot",
+            "fa-regular-400.woff2": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-regular-400.woff2",
+            "fa-regular-400.woff": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-regular-400.woff",
+            "fa-regular-400.ttf": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-regular-400.ttf",
+            "fa-regular-400.eot": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-regular-400.eot",
+        }
+        
+        if font_file in font_mapping:
+            return RedirectResponse(url=font_mapping[font_file], status_code=302)
+        else:
+            # For any other font file, redirect to solid font as fallback
+            return RedirectResponse(
+                url="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-solid-900.woff2",
+                status_code=302
+            )
+    except Exception as e:
+        # If anything fails, redirect to CDN anyway
+        return RedirectResponse(
+            url="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-solid-900.woff2",
+            status_code=302
+        )
+
+# Add favicon route to prevent 404 errors
+@app.get("/favicon.ico")
+async def favicon():
+    """Return a simple favicon to prevent 404 errors"""
+    from fastapi.responses import Response
+    # Return a minimal 1x1 transparent PNG
+    favicon_data = b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n-\xdb\x00\x00\x00\x00IEND\xaeB`\x82'
+    return Response(content=favicon_data, media_type="image/png")
+
+# Add CSS file redirects to prevent 404 errors for missing SQLAdmin CSS
+@app.get("/admin/statics/css/fontawesome.min.css")
+async def fontawesome_css_redirect():
+    """Redirect FontAwesome CSS to CDN to prevent 404 errors"""
+    from fastapi.responses import RedirectResponse
+    return RedirectResponse(
+        url="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css",
+        status_code=302
+    )
+
+# Middleware to inject FontAwesome CDN CSS
+@app.middleware("http")
+async def inject_fontawesome_cdn(request: Request, call_next):
+    """Inject FontAwesome CDN CSS into admin pages"""
+    response = await call_next(request)
+    
+    # Only process admin HTML pages (not static assets)
+    if (request.url.path.startswith("/admin/") and 
+        not request.url.path.startswith("/admin/statics/") and
+        not request.url.path.startswith("/admin/static/") and
+        not request.url.path.endswith(('.css', '.js', '.png', '.jpg', '.jpeg', '.gif', '.ico', '.woff', '.woff2', '.ttf', '.eot'))):
+        try:
+            # Get response body
+            body = b""
+            if hasattr(response, 'body'):
+                body = response.body
+            elif hasattr(response, 'content'):
+                body = response.content
+            elif hasattr(response, 'text'):
+                body = response.text.encode('utf-8')
+            elif hasattr(response, 'body_iterator'):
+                # Handle streaming responses
+                async for chunk in response.body_iterator:
+                    body += chunk
+            
+            if body:
+                html = body.decode('utf-8')
+                
+                # Check if this is an HTML page and doesn't already have FontAwesome CDN
+                if ("<html" in html.lower() and 
+                    "font-awesome" not in html.lower() and 
+                    "cdnjs.cloudflare.com" not in html):
+                    
+                    # Inject FontAwesome CDN CSS early in head to prevent layout warnings
+                    cdn_css = '''<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" crossorigin="anonymous">
+    <style>
+        /* Override SQLAdmin's font loading with CDN fonts */
+        @font-face {
+            font-family: "Font Awesome 6 Free";
+            font-style: normal;
+            font-weight: 900;
+            font-display: block;
+            src: url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-solid-900.woff2") format("woff2");
+        }
+        @font-face {
+            font-family: "Font Awesome 5 Free";
+            font-style: normal;
+            font-weight: 900;
+            font-display: block;
+            src: url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-solid-900.woff2") format("woff2");
+        }
+        @font-face {
+            font-family: "Font Awesome 6 Free";
+            font-style: normal;
+            font-weight: 400;
+            font-display: block;
+            src: url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/webfonts/fa-regular-400.woff2") format("woff2");
+        }
+        /* Ensure FontAwesome icons use CDN fonts */
+        .fa, .fas, .far, .fal, .fab {
+            font-family: "Font Awesome 6 Free" !important;
+        }
+    </style>'''
+                    
+                    # Inject early in head, right after opening head tag
+                    if "<head>" in html:
+                        html = html.replace("<head>", f"<head>{cdn_css}")
+                    elif "</head>" in html:
+                        html = html.replace("</head>", f"{cdn_css}</head>")
+                    else:
+                        html = html.replace("</body>", f"{cdn_css}</body>")
+                    
+                    # Return new response with proper headers (no Content-Length)
+                    from fastapi.responses import HTMLResponse
+                    new_headers = dict(response.headers)
+                    # Remove Content-Length to let FastAPI calculate it
+                    new_headers.pop('content-length', None)
+                    return HTMLResponse(content=html, status_code=response.status_code, headers=new_headers)
+        
+        except Exception as e:
+            print(f"FontAwesome injection error: {e}")
+    
+    return response
+
+# Include routers
+app.include_router(health_router)
+app.include_router(chat_router, prefix="/api")
+app.include_router(api_router, prefix="/api")
+if auth_router:
+    app.include_router(auth_router)
+app.include_router(pages_router)
+if webinar_router:
+    app.include_router(webinar_router)
+if oppman_router:
+    app.include_router(oppman_router, prefix="/oppman")
+if oppdemo_router:
+    app.include_router(oppdemo_router)
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):
+    """Handle HTTP exceptions and redirect to login if authentication fails"""
+    if exc.status_code in [401, 403]:
+        # Preserve the original URL as a redirect parameter
+        original_url = str(request.url)
+        login_url = f"/login?next={original_url}"
+        return RedirectResponse(url=login_url, status_code=302)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"detail": exc.detail},
+    )
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    """Handle global exceptions, especially database connection errors"""
+    from dependencies.database_health import is_database_available
+    
+    # Check if this is a database-related error
+    if "database" in str(exc).lower() or "sqlite" in str(exc).lower() or "operational" in str(exc).lower():
+        # Check if database is available
+        db_available = await is_database_available()
+        
+        if not db_available:
+            # Redirect to database status page for database issues
+            return RedirectResponse(url="/database-status", status_code=302)
+    
+    # For other exceptions, return a generic error
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal server error. Please try again later."}
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,13 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "fastopp"
-version = "0.2.0"
-authors = ["Oppkey"]
+version = "0.2.3"
+authors = [
+    {name = "Oppkey"}
+]
 description = "FastAPI starter package for students prototyping AI web applications."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -26,6 +32,8 @@ dependencies = [
     "httpx>=0.28.1",
     "psycopg[binary]>=3.2.11",
     "boto3>=1.40.55",
+    "hatchling>=1.27.0",
+    "twine>=6.2.0",
 ]
 
 [dependency-groups]
@@ -43,3 +51,9 @@ test = [
     "httpx>=0.28.1",
     "pytest-xdist>=3.8.0",
 ]
+
+[project.scripts]
+fastopp = "fastopp:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["fastopp"]

--- a/uv.lock
+++ b/uv.lock
@@ -576,6 +576,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docutils"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/c0/89fe6215b443b919cb98a5002e107cb5026854ed1ccb6b5833e0768419d1/docutils-0.22.2.tar.gz", hash = "sha256:9fdb771707c8784c8f2728b67cb2c691305933d68137ef95a75db5f4dfbc213d", size = 2289092, upload-time = "2025-09-20T17:55:47.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/dd/f95350e853a4468ec37478414fc04ae2d61dad7a947b3015c3dcc51a09b9/docutils-0.22.2-py3-none-any.whl", hash = "sha256:b0e98d679283fc3bb0ead8a5da7f501baa632654e7056e9c5846842213d674d8", size = 632667, upload-time = "2025-09-20T17:55:43.052Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -648,8 +657,8 @@ wheels = [
 
 [[package]]
 name = "fastopp"
-version = "0.2.0"
-source = { virtual = "." }
+version = "0.2.3"
+source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiosqlite" },
@@ -657,6 +666,7 @@ dependencies = [
     { name = "boto3" },
     { name = "fastapi" },
     { name = "fastapi-users", extra = ["sqlalchemy"] },
+    { name = "hatchling" },
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "jinja2" },
@@ -670,6 +680,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "sqlmodel" },
     { name = "sse-starlette" },
+    { name = "twine" },
     { name = "uvicorn" },
 ]
 
@@ -696,6 +707,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.40.55" },
     { name = "fastapi", specifier = ">=0.119.1" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14.0.1" },
+    { name = "hatchling", specifier = ">=1.27.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -709,22 +721,23 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.44" },
     { name = "sqlmodel", specifier = ">=0.0.27" },
     { name = "sse-starlette", specifier = ">=3.0.2" },
+    { name = "twine", specifier = ">=6.2.0" },
     { name = "uvicorn", specifier = ">=0.38.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.17.1" },
-    { name = "ruff", specifier = ">=0.12.7" },
+    { name = "ruff", specifier = ">=0.14.1" },
 ]
 test = [
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "pytest", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.23.0" },
-    { name = "pytest-cov", specifier = ">=4.0.0" },
-    { name = "pytest-mock", specifier = ">=3.12.0" },
-    { name = "pytest-timeout", specifier = ">=2.2.0" },
-    { name = "pytest-xdist", specifier = ">=3.5.0" },
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
 ]
 
 [[package]]
@@ -859,6 +872,21 @@ wheels = [
 ]
 
 [[package]]
+name = "hatchling"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/8a/cc1debe3514da292094f1c3a700e4ca25442489731ef7c0814358816bb03/hatchling-1.27.0.tar.gz", hash = "sha256:971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6", size = 54983, upload-time = "2024-12-15T17:08:11.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/e7/ae38d7a6dfba0533684e0b2136817d667588ae3ec984c1a4e5df5eb88482/hatchling-1.27.0-py3-none-any.whl", hash = "sha256:d3a2f3567c4f926ea39849cdf924c7e99e6686c9c8e288ae1037c8fa2a5d937b", size = 75794, upload-time = "2024-12-15T17:08:10.364Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -884,6 +912,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "id"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/11/102da08f88412d875fa2f1a9a469ff7ad4c874b0ca6fed0048fe385bdb3d/id-1.5.0.tar.gz", hash = "sha256:292cb8a49eacbbdbce97244f47a97b4c62540169c976552e497fd57df0734c1d", size = 15237, upload-time = "2024-12-04T19:53:05.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/cb/18326d2d89ad3b0dd143da971e77afd1e6ca6674f1b1c3df4b6bec6279fc/id-1.5.0-py3-none-any.whl", hash = "sha256:f1434e1cef91f2cbb8a4ec64663d5a23b9ed43ef44c4c957d02583d61714c658", size = 13611, upload-time = "2024-12-04T19:53:03.02Z" },
 ]
 
 [[package]]
@@ -914,6 +954,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3", size = 13912, upload-time = "2024-08-20T03:39:27.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl", hash = "sha256:f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4", size = 6825, upload-time = "2024-08-20T03:39:25.966Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ed/1aa2d585304ec07262e1a83a9889880701079dde796ac7b1d1826f40c63d/jaraco_functools-4.3.0.tar.gz", hash = "sha256:cfd13ad0dd2c47a3600b439ef72d8615d482cedcff1632930d6f28924d92f294", size = 19755, upload-time = "2025-08-18T20:05:09.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/09/726f168acad366b11e420df31bf1c702a54d373a83f968d94141a8c3fde0/jaraco_functools-4.3.0-py3-none-any.whl", hash = "sha256:227ff8ed6f7b8f62c56deff101545fa7543cf2c8e7b82a7c2116e672f29c26e8", size = 10408, upload-time = "2025-08-18T20:05:08.69Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -932,6 +1014,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz", hash = "sha256:0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66", size = 62750, upload-time = "2024-12-25T15:26:45.782Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl", hash = "sha256:552a3f7af126ece7ed5c89753650eec89c7eaae8617d0aa4d9ad2b75111266bd", size = 39085, upload-time = "2024-12-25T15:26:44.377Z" },
 ]
 
 [[package]]
@@ -962,6 +1061,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8d/37/02347f6d6d8279247a5837082ebc26fc0d5aaeaf75aa013fcbb433c777ab/markdown-3.9.tar.gz", hash = "sha256:d2900fe1782bd33bdbbd56859defef70c2e78fc46668f8eb9df3128138f2cb6a", size = 364585, upload-time = "2025-09-04T20:25:22.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/ae/44c4a6a4cbb496d93c6257954260fe3a6e91b7bed2240e5dad2a717f5111/markdown-3.9-py3-none-any.whl", hash = "sha256:9f4d91ed810864ea88a6f32c07ba8bee1346c0cc1f6b1f9f6c822f2a9667d280", size = 107441, upload-time = "2025-09-04T20:25:21.784Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
 ]
 
 [[package]]
@@ -1025,6 +1136,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
 ]
 
 [[package]]
@@ -1165,6 +1294,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nh3"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/a6/c6e942fc8dcadab08645f57a6d01d63e97114a30ded5f269dc58e05d4741/nh3-0.3.1.tar.gz", hash = "sha256:6a854480058683d60bdc7f0456105092dae17bef1f300642856d74bd4201da93", size = 18590, upload-time = "2025-10-07T03:27:58.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/24/4becaa61e066ff694c37627f5ef7528901115ffa17f7a6693c40da52accd/nh3-0.3.1-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:80dc7563a2a3b980e44b221f69848e3645bbf163ab53e3d1add4f47b26120355", size = 1420887, upload-time = "2025-10-07T03:27:25.654Z" },
+    { url = "https://files.pythonhosted.org/packages/94/49/16a6ec9098bb9bdf0fb9f09d6464865a3a48858d8d96e779a998ec3bdce0/nh3-0.3.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f600ad86114df21efc4a3592faa6b1d099c0eebc7e018efebb1c133376097da", size = 791700, upload-time = "2025-10-07T03:27:27.041Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/cc/1c024d7c23ad031dfe82ad59581736abcc403b006abb0d2785bffa768b54/nh3-0.3.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:669a908706cd28203d9cfce2f567575686e364a1bc6074d413d88d456066f743", size = 830225, upload-time = "2025-10-07T03:27:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/89/08/4a87f9212373bd77bba01c1fd515220e0d263316f448d9c8e4b09732a645/nh3-0.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a5721f59afa0ab3dcaa0d47e58af33a5fcd254882e1900ee4a8968692a40f79d", size = 999112, upload-time = "2025-10-07T03:27:29.782Z" },
+    { url = "https://files.pythonhosted.org/packages/19/cf/94783911eb966881a440ba9641944c27152662a253c917a794a368b92a3c/nh3-0.3.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:2cb6d9e192fbe0d451c7cb1350dadedbeae286207dbf101a28210193d019752e", size = 1070424, upload-time = "2025-10-07T03:27:31.2Z" },
+    { url = "https://files.pythonhosted.org/packages/71/44/efb57b44e86a3de528561b49ed53803e5d42cd0441dcfd29b89422160266/nh3-0.3.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:474b176124c1b495ccfa1c20f61b7eb83ead5ecccb79ab29f602c148e8378489", size = 996129, upload-time = "2025-10-07T03:27:32.595Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/d3/87c39ea076510e57ee99a27fa4c2335e9e5738172b3963ee7c744a32726c/nh3-0.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4a2434668f4eef4eab17c128e565ce6bea42113ce10c40b928e42c578d401800", size = 980310, upload-time = "2025-10-07T03:27:34.282Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/30/00cfbd2a4d268e8d3bda9d1542ba4f7a20fbed37ad1e8e51beeee3f6fdae/nh3-0.3.1-cp313-cp313t-win32.whl", hash = "sha256:0f454ba4c6aabafcaae964ae6f0a96cecef970216a57335fabd229a265fbe007", size = 584439, upload-time = "2025-10-07T03:27:36.103Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fa/39d27a62a2f39eb88c2bd50d9fee365a3645e456f3ec483c945a49c74f47/nh3-0.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:22b9e9c9eda497b02b7273b79f7d29e1f1170d2b741624c1b8c566aef28b1f48", size = 592388, upload-time = "2025-10-07T03:27:37.075Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/39/7df1c4ee13ef65ee06255df8101141793e97b4326e8509afbce5deada2b5/nh3-0.3.1-cp313-cp313t-win_arm64.whl", hash = "sha256:42e426f36e167ed29669b77ae3c4b9e185e4a1b130a86d7c3249194738a1d7b2", size = 579337, upload-time = "2025-10-07T03:27:38.055Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/28/a387fed70438d2810c8ac866e7b24bf1a5b6f30ae65316dfe4de191afa52/nh3-0.3.1-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:1de5c1a35bed19a1b1286bab3c3abfe42e990a8a6c4ce9bb9ab4bde49107ea3b", size = 1433666, upload-time = "2025-10-07T03:27:39.118Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f9/500310c1f19cc80770a81aac3c94a0c6b4acdd46489e34019173b2b15a50/nh3-0.3.1-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eaba26591867f697cffdbc539faddeb1d75a36273f5bfe957eb421d3f87d7da1", size = 819897, upload-time = "2025-10-07T03:27:40.488Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/d4/ebb0965d767cba943793fa8f7b59d7f141bd322c86387a5e9485ad49754a/nh3-0.3.1-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:489ca5ecd58555c2865701e65f614b17555179e71ecc76d483b6f3886b813a9b", size = 803562, upload-time = "2025-10-07T03:27:41.86Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/9c/df037a13f0513283ecee1cf99f723b18e5f87f20e480582466b1f8e3a7db/nh3-0.3.1-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:5a25662b392b06f251da6004a1f8a828dca7f429cd94ac07d8a98ba94d644438", size = 1050854, upload-time = "2025-10-07T03:27:43.29Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9d/488fce56029de430e30380ec21f29cfaddaf0774f63b6aa2bf094c8b4c27/nh3-0.3.1-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:38b4872499ab15b17c5c6e9f091143d070d75ddad4a4d1ce388d043ca556629c", size = 1002152, upload-time = "2025-10-07T03:27:44.358Z" },
+    { url = "https://files.pythonhosted.org/packages/da/4a/24b0118de34d34093bf03acdeca3a9556f8631d4028814a72b9cc5216382/nh3-0.3.1-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48425995d37880281b467f7cf2b3218c1f4750c55bcb1ff4f47f2320a2bb159c", size = 912333, upload-time = "2025-10-07T03:27:45.757Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0e/16b3886858b3953ef836dea25b951f3ab0c5b5a431da03f675c0e999afb8/nh3-0.3.1-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94292dd1bd2a2e142fa5bb94c0ee1d84433a5d9034640710132da7e0376fca3a", size = 796945, upload-time = "2025-10-07T03:27:47.169Z" },
+    { url = "https://files.pythonhosted.org/packages/87/bb/aac139cf6796f2e0fec026b07843cea36099864ec104f865e2d802a25a30/nh3-0.3.1-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dd6d1be301123a9af3263739726eeeb208197e5e78fc4f522408c50de77a5354", size = 837257, upload-time = "2025-10-07T03:27:48.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d7/1d770876a288a3f5369fd6c816363a5f9d3a071dba24889458fdeb4f7a49/nh3-0.3.1-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b74bbd047b361c0f21d827250c865ff0895684d9fcf85ea86131a78cfa0b835b", size = 1004142, upload-time = "2025-10-07T03:27:49.278Z" },
+    { url = "https://files.pythonhosted.org/packages/31/2a/c4259e8b94c2f4ba10a7560e0889a6b7d2f70dce7f3e93f6153716aaae47/nh3-0.3.1-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:b222c05ae5139320da6caa1c5aed36dd0ee36e39831541d9b56e048a63b4d701", size = 1075896, upload-time = "2025-10-07T03:27:50.527Z" },
+    { url = "https://files.pythonhosted.org/packages/59/06/b15ba9fea4773741acb3382dcf982f81e55f6053e8a6e72a97ac91928b1d/nh3-0.3.1-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:b0d6c834d3c07366ecbdcecc1f4804c5ce0a77fa52ee4653a2a26d2d909980ea", size = 1003235, upload-time = "2025-10-07T03:27:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/13/74707f99221bbe0392d18611b51125d45f8bd5c6be077ef85575eb7a38b1/nh3-0.3.1-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:670f18b09f75c86c3865f79543bf5acd4bbe2a5a4475672eef2399dd8cdb69d2", size = 987308, upload-time = "2025-10-07T03:27:53.003Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/81/24bf41a5ce7648d7e954de40391bb1bcc4b7731214238c7138c2420f962c/nh3-0.3.1-cp38-abi3-win32.whl", hash = "sha256:d7431b2a39431017f19cd03144005b6c014201b3e73927c05eab6ca37bb1d98c", size = 591695, upload-time = "2025-10-07T03:27:54.43Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ca/263eb96b6d32c61a92c1e5480b7f599b60db7d7fbbc0d944be7532d0ac42/nh3-0.3.1-cp38-abi3-win_amd64.whl", hash = "sha256:c0acef923a1c3a2df3ee5825ea79c149b6748c6449781c53ab6923dc75e87d26", size = 600564, upload-time = "2025-10-07T03:27:55.966Z" },
+    { url = "https://files.pythonhosted.org/packages/34/67/d5e07efd38194f52b59b8af25a029b46c0643e9af68204ee263022924c27/nh3-0.3.1-cp38-abi3-win_arm64.whl", hash = "sha256:a3e810a92fb192373204456cac2834694440af73d749565b4348e30235da7f0b", size = 586369, upload-time = "2025-10-07T03:27:57.234Z" },
 ]
 
 [[package]]
@@ -1586,6 +1748,29 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "readme-renderer"
+version = "44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "nh3" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056, upload-time = "2024-07-08T15:00:57.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310, upload-time = "2024-07-08T15:00:56.577Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1598,6 +1783,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "rfc3986"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
 ]
 
 [[package]]
@@ -1636,6 +1855,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/9f/11ef35cf1027c1339552ea7bfe6aaa74a8516d8b5caf6e7d338daf54fd80/secretstorage-3.4.0.tar.gz", hash = "sha256:c46e216d6815aff8a8a18706a2fbfd8d53fcbb0dce99301881687a1b0289ef7c", size = 19748, upload-time = "2025-09-09T16:42:13.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/ff/2e2eed29e02c14a5cb6c57f09b2d5b40e65d6cc71f45b52e0be295ccbc2f/secretstorage-3.4.0-py3-none-any.whl", hash = "sha256:0e3b6265c2c63509fb7415717607e4b2c9ab767b7f344a57473b779ca13bd02e", size = 15272, upload-time = "2025-09-09T16:42:12.744Z" },
 ]
 
 [[package]]
@@ -1742,6 +1974,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2025.9.11.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/9a/778622bc06632529817c3c524c82749a112603ae2bbcf72ee3eb33a2c4f1/trove_classifiers-2025.9.11.17.tar.gz", hash = "sha256:931ca9841a5e9c9408bc2ae67b50d28acf85bef56219b56860876dd1f2d024dd", size = 16975, upload-time = "2025-09-11T17:07:50.97Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/85/a4ff8758c66f1fc32aa5e9a145908394bf9cf1c79ffd1113cfdeb77e74e4/trove_classifiers-2025.9.11.17-py3-none-any.whl", hash = "sha256:5d392f2d244deb1866556457d6f3516792124a23d1c3a463a2e8668a5d1c15dd", size = 14158, upload-time = "2025-09-11T17:07:49.886Z" },
+]
+
+[[package]]
+name = "twine"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "id" },
+    { name = "keyring", marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'" },
+    { name = "packaging" },
+    { name = "readme-renderer" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "rfc3986" },
+    { name = "rich" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Fix PyPI README Image Display and Update Package Configuration

## 🐛 Problem
The PyPI package page was missing all images from the README.md file because local image paths (`docs/images/...`) don't work on PyPI. This made the package page look unprofessional and incomplete.

## ✅ Solution
- **Updated all image URLs** to use GitHub raw URLs for proper display on PyPI
- **Incremented package version** from 0.2.2 to 0.2.3
- **Maintained image quality** while ensuring PyPI compatibility

## 📝 Changes Made

### Image URL Updates
- **Before**: `docs/images/fastopp_logo.webp` (local path - broken on PyPI)
- **After**: `https://raw.githubusercontent.com/Oppkey/fastopp/main/docs/images/fastopp_logo.webp` (GitHub raw URL - works on PyPI)

### Updated Images
- ✅ FastOpp logo
- ✅ All demo screenshots (home, interactive, hero, admin, etc.)
- ✅ UI component examples
- ✅ Authentication screenshots
- ✅ AI chat interface examples
- ✅ Emergency access screenshots
- ✅ Admin dashboard screenshots
- ✅ Demo management screenshots

### Version Update
- **Version**: 0.2.2 → 0.2.3
- **Reason**: New release with image fixes

## 🎯 Impact

### Before
- ❌ PyPI page showed broken image placeholders
- ❌ Unprofessional appearance
- ❌ Users couldn't see what the package offers

### After
- ✅ All images display correctly on PyPI
- ✅ Professional, complete package page
- ✅ Users can see all features and screenshots
- ✅ Better package discoverability and adoption

## 🧪 Testing

### Verified
- [x] All images load correctly on GitHub
- [x] Package builds successfully with `uv build`
- [x] Package uploads to PyPI without errors
- [x] Images display properly on PyPI package page
- [x] Version increment follows semantic versioning

### Test Commands
```bash
# Build package
uv build

# Upload to PyPI
TWINE_USERNAME=__token__ TWINE_PASSWORD=your-token uv run twine upload dist/*

# Verify on PyPI
# Visit: https://pypi.org/project/fastopp/0.2.3/
```

## 📋 Checklist

- [x] All image URLs updated to GitHub raw URLs
- [x] Version incremented in pyproject.toml
- [x] Package builds successfully
- [x] Package uploads to PyPI
- [x] Images display correctly on PyPI
- [x] No breaking changes
- [x] Documentation remains accurate

## 🔗 Related

- **PyPI Package**: https://pypi.org/project/fastopp/0.2.3/
- **GitHub Repository**: https://github.com/Oppkey/fastopp
- **Issue**: PyPI images not displaying

## 📸 Screenshots

### Before (Broken Images)
- PyPI page showed broken image placeholders
- Unprofessional appearance

### After (Working Images)
- All images display correctly
- Professional package presentation
- Complete feature showcase

## 🚀 Deployment

This change is ready for immediate deployment:
1. ✅ Code changes complete
2. ✅ Package version updated
3. ✅ PyPI upload successful
4. ✅ Images verified working

## 📚 Documentation

The contributing guide has been updated to include:
- PyPI publishing process
- Image URL best practices
- Version management guidelines
- Access control for maintainers

---

**Type**: Bug Fix + Enhancement  
**Priority**: High  
**Breaking Changes**: None  
**Dependencies**: None
