### PR TITLE
changing to display LLM being used in ai-demo

### DIFF
--- a/templates/ai-demo.html
+++ b/templates/ai-demo.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ title }} - AI Chat with Llama 3.3 70B</title>
+    <title>{{ title }} - AI Chat with {{ llm_model_display or llm_model }}</title>
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='/favicon.ico') }}">
     
     <!-- Tailwind CSS CDN -->
@@ -363,7 +363,7 @@
                             </div>
                             <div>
                                 <h3 class="text-white font-semibold text-lg">Single Tatami Mat AI</h3>
-                                <p class="text-blue-100 text-sm">Powered by Llama 3.3 70B</p>
+                                <p class="text-blue-100 text-sm">Powered by {{ llm_model_display or llm_model }}</p>
                             </div>
                         </div>
                         <div class="flex items-center space-x-4">
@@ -392,7 +392,7 @@
                     <!-- Welcome Message -->
                     <div class="chat chat-start">
                         <div class="chat-bubble bg-gradient-to-r from-blue-100 to-purple-100 text-gray-800 border border-blue-200">
-                            <p>👋 Hello! I'm Midori, powered by Llama 3.3 70B. How can I help you today?</p>
+                            <p>👋 Hello! I'm Midori, powered by {{ llm_model_display or llm_model }}. How can I help you today?</p>
                             <p class="text-xs opacity-70 mt-2">Just type your message below to start chatting!</p>
                         </div>
                         <div class="chat-footer opacity-50">Midori</div>

--- a/uv.lock
+++ b/uv.lock
@@ -657,7 +657,7 @@ wheels = [
 
 [[package]]
 name = "fastopp"
-version = "0.4.3"
+version = "0.4.5a0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
"Powered by" message in Single Tatami Mat demo does not change when LLM is changed

When changing LLMs setting in .env, the status info in the console changes. Setting to 

`OPENROUTER_LLM_MODEL=openai/gpt-oss-20b:free`

shows

INFO:     Will watch for changes in these directories: ['/Users/jcasman/Development/Practice/fastopp-pypi2']
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     Started reloader process [8316] using StatReload
<mark>🤖 Using LLM Model: openai/gpt-oss-20b:free</mark>
INFO:services.chat_service:LLM Model configured: openai/gpt-oss-20b:free
✅ Dependencies setup complete - session_factory: async_sessionmaker(class_='AsyncSession', autocommit=False, bind=<sqlalchemy.ext.asyncio.engine.AsyncEngine object at 0x104ab4b90>, autoflush=False, expire_on_commit=False)
✅ App state after setup: ['_state']
🔧 Setting up SQLAdmin with unified authentication
🔧 Created AdminAuth backend: <core.services.auth.admin.AdminAuth object at 0x10521e0f0>
🔧 SQLAdmin created with authentication: <core.services.auth.admin.AdminAuth object at 0x10521e0f0>
INFO:     Started server process [8318]
INFO:     Waiting for application startup.
INFO:     Application startup complete.

But in http://0.0.0.0:8000/ai-demo, it only displays

👋 Hello! I'm Midori, powered by Llama 3.3 70B. How can I help you today?


Second example. Changing to 

`OPENROUTER_LLM_MODEL=meta-llama/llama-3.3-70b-instruct:free`

shows

INFO:     Started server process [8269]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     127.0.0.1:56926 - "GET / HTTP/1.1" 200 OK
INFO:     127.0.0.1:56927 - "GET /ai-demo HTTP/1.1" 200 OK
DEBUG: Testing connection with API key: sk-or-v1-3...
DEBUG: Making test request to OpenRouter...
DEBUG: Test response status: 200
DEBUG: Test response: {'id': 'gen-1761341732-QvyN2unJWNtMRFtAOWYp', 'provider': 'Together', 'model': 'meta-llama/<mark>llama-3.3-70b-instruct:free</mark>', 'object': 'chat.completion', 'created': 1761341732, 'choices': [{'logprobs': None, 'finish_reason': 'stop', 'native_finish_reason': 'stop', 'index': 0, 'message': {'role': 'assistant', 'content': 'Hello! How can I assist you today?', 'refusal': None, 'reasoning': None}}], 'usage': {'prompt_tokens': 11, 'completion_tokens': 10, 'total_tokens': 21}}

But in http://0.0.0.0:8000/ai-demo, it only displays

👋 Hello! I'm Midori, powered by Llama 3.3 70B. How can I help you today?

Built this plan, executed it on a branch, and am creating this Pull Request


# Dynamic LLM Model Display

## Problem

The `ai-demo.html` template currently displays hardcoded text "Powered by Llama 3.3 70B" regardless of which LLM model is actually configured in the `.env` file via `OPENROUTER_LLM_MODEL`.

## Solution Overview

Pass the LLM model information from the backend to the template and update all hardcoded references to use the dynamic value.

## Changes Required

### 1. Update `/routes/pages.py` - `ai_demo()` function (lines 73-80)

- Import `os` module to read environment variables
- Read the `OPENROUTER_LLM_MODEL` environment variable (with the same default as `chat_service.py`)
- Optionally create a helper function to format the model name for display (e.g., "meta-llama/llama-3.3-70b-instruct:free" → "Llama 3.3 70B Instruct (Free)")
- Pass the `llm_model` (and optionally `llm_model_display`) to the template context

### 2. Update `/templates/ai-demo.html`

Update three locations where "Llama 3.3 70B" is hardcoded:

- **Line 6**: Page title - use `{{ llm_model_display or llm_model }}`
- **Line 366**: Chat header subtitle - change "Powered by Llama 3.3 70B" to "Powered by {{ llm_model_display or llm_model }}"
- **Line 395**: Welcome message - change "powered by Llama 3.3 70B" to "powered by {{ llm_model_display or llm_model }}"



