### PR TITLE
updating LLMs models section in example dot env file

### DIFF
--- a/example.env
+++ b/example.env
@@ -128,17 +128,30 @@ EMERGENCY_ACCESS_ENABLED=false
 
 
 # =============================================================================
-# OPTIONAL OPENROUTER LLM MODELS
+# EXAMPLE OPENROUTER LLM MODELS
 # =============================================================================
 # Highly suggest you use a paid model as the free version
-# has strict usage limits
-# default: meta-llama/llama-3.3-70b-instruct:free  
-# OPENROUTER_LLM_MODEL=meta-llama/llama-3.3-70b-instruct:free
-# Alternative models you can use:
-# OPENROUTER_LLM_MODEL=meta-llama/llama-3.3-70b-instruct  # Paid version
+# has strict usage limits. If none of the LLMs examples below are uncommented
+# the default setting for FastOpp is free meta-llama/llama-3.3-70b-instruct:free
 
+# PAID
+# =============================================================================
+# paid models: https://openrouter.ai/models?max_price=0.1
+# OPENROUTER_LLM_MODEL=google/gemini-2.5-flash-lite-preview-09-2025
+# Google model, detailed responses, great formatting
+# OPENROUTER_LLM_MODEL=liquid/lfm2-8b-a1b
+# Liquid AI model, startup spun out of MIT, fast, complete responses, good formatting, emojis.
+# OPENROUTER_LLM_MODEL=meta-llama/llama-3.3-70b-instruct
+# Meta model, complete responses, medium performance. Paid version of FastOpp default LLM.
+# OPENROUTER_LLM_MODEL=qwen/qwen-2.5-72b-instruct
+# Alibaba Cloud model, complete responses tend toward lists, medium performance.
+
+# FREE
+# =============================================================================
 # free models: https://openrouter.ai/models?max_price=0
-# example this was free as of Oct 22, 2025 qwen/qwen3-coder:free
+# default: meta-llama/llama-3.3-70b-instruct:free 
+# OPENROUTER_LLM_MODEL=openai/gpt-oss-20b:free
+# Extended responses, good formatting. Slightly lower performance (response time).
 
 
 # =============================================================================


### PR DESCRIPTION
WAS
```
# =============================================================================
# OPTIONAL OPENROUTER LLM MODELS
# =============================================================================
# Highly suggest you use a paid model as the free version
# has strict usage limits
# default: meta-llama/llama-3.3-70b-instruct:free  
# OPENROUTER_LLM_MODEL=meta-llama/llama-3.3-70b-instruct:free
# Alternative models you can use:
# OPENROUTER_LLM_MODEL=meta-llama/llama-3.3-70b-instruct  # Paid version

# free models: https://openrouter.ai/models?max_price=0
# example this was free as of Oct 22, 2025 qwen/qwen3-coder:free
```

NEW

```
# =============================================================================
# EXAMPLE OPENROUTER LLM MODELS
# =============================================================================
# Highly suggest you use a paid model as the free version
# has strict usage limits. If none of the LLMs examples below are uncommented
# the default setting for FastOpp is free meta-llama/llama-3.3-70b-instruct:free

# PAID
# =============================================================================
# paid models: https://openrouter.ai/models?max_price=0.1
# OPENROUTER_LLM_MODEL=google/gemini-2.5-flash-lite-preview-09-2025
# Google model, detailed responses, great formatting
# OPENROUTER_LLM_MODEL=liquid/lfm2-8b-a1b
# Liquid AI model, startup spun out of MIT, fast, complete responses, good formatting, emojis.
# OPENROUTER_LLM_MODEL=meta-llama/llama-3.3-70b-instruct
# Meta model, complete responses, medium performance. Paid version of FastOpp default LLM.
# OPENROUTER_LLM_MODEL=qwen/qwen-2.5-72b-instruct
# Alibaba Cloud model, complete responses tend toward lists, medium performance.

# FREE
# =============================================================================
# free models: https://openrouter.ai/models?max_price=0
# default: meta-llama/llama-3.3-70b-instruct:free 
# OPENROUTER_LLM_MODEL=openai/gpt-oss-20b:free
# Extended responses, good formatting. Slightly lower performance (response time).
```

